### PR TITLE
Affordance for expandable content

### DIFF
--- a/source/assets/stylesheets/components/_signage.scss
+++ b/source/assets/stylesheets/components/_signage.scss
@@ -2,7 +2,7 @@
   // background: var(--background-color--tinted);
   border: var(--border);
   border-radius: var(--border-radius);
-  font-size: var(--font-size--small);
+  font-size: 80%;
   font-weight: var(--font-weight--bold);
   display: inline-block;
   padding: 0.05rem 0.25rem 0;

--- a/source/assets/stylesheets/elements/_lists.scss
+++ b/source/assets/stylesheets/elements/_lists.scss
@@ -22,13 +22,28 @@ details {
   summary {
     cursor: pointer;
     list-style: none;
+    position: relative;
 
     &:focus {
       outline: none;
     }
-
     &::-webkit-details-marker {
       display: none; // hides marker in Webkit
+    }
+
+    &::after {
+      content: "\00002b";
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+  }
+
+  &[open] {
+    summary {
+      &::after {
+        content: "\0000d7";
+      }
     }
   }
 }

--- a/source/assets/stylesheets/settings/_variables.scss
+++ b/source/assets/stylesheets/settings/_variables.scss
@@ -1,7 +1,7 @@
 :root {
   // Colors
-  --background-color: hsl(0, 0%, 96%);
-  --background-color--tinted: hsl(0, 0%, 93%);
+  --background-color: hsl(0, 0%, 100%);
+  --background-color--tinted: hsl(0, 0%, 95%);
   --font-color: hsl(0, 0%, 0%);
   --font-color--dimmed: hsla(0, 0%, 60%);
 


### PR DESCRIPTION
This PR provides an affordance for expandable content.

## Before
<img width="375" alt="Screen Shot 2019-11-15 at 14 06 40" src="https://user-images.githubusercontent.com/28635708/68968766-5c750480-07b1-11ea-814c-b98a157eff7b.png"/>

## After
<img width="375" alt="Screen Shot 2019-11-15 at 16 55 05" src="https://user-images.githubusercontent.com/28635708/68978473-dbc20280-07c8-11ea-995f-3d50574aba8e.png"/>
