### PR TITLE
Improve signage

### DIFF
--- a/source/articles/help/directions.html.md
+++ b/source/articles/help/directions.html.md
@@ -9,7 +9,7 @@ date: 2019-08-28 06:00 UTC
 
 1. Buy a Metrocard. You can pay for the AirTrain and the subway with Metrocards — the AirTrain when exiting ($5), the subway when entering ($2.75/ride).
 
-1. Ride the <span class="signage signage--subway">E</span> train in the direction of Manhattan and get off at <span class="signage">Times Sq-42nd St</span>.
+1. Ride the <span class="signage signage--subway">E</span> train to Manhattan and get off at <span class="signage">Times Sq-42nd St</span>.
 
 1. Exit the platform. Stay in the station, and follow signs for Port Authority and/or 40th St.
 
@@ -28,7 +28,7 @@ date: 2019-08-28 06:00 UTC
 1. Take any escalator up to the 200-level departure gates.
 
     <aside>
-    If after 10 pm, take the escalators up another floor to the 300-level gates.
+    If after 10pm, take the escalators up another floor to the 300-level gates.
     </aside>
 
 1. Buy a NJTransit bus ticket ($3.50), either from one of the orange vending machines or by downloading the NJTransit app on your phone. You'll need a credit or debit card.
@@ -38,7 +38,7 @@ date: 2019-08-28 06:00 UTC
 1. Go to gate <span class="signage">212</span>. (During rush hour, the line may snake down the gate escalator and back through the terminal. Don't worry; it moves fast.)
 
     <aside>
-    If after 10 pm, go to gate <span class="signage">325</span>.
+    If after 10pm, go to gate <span class="signage">325</span>.
     </aside>
 
 1. Take any bus from any door.

--- a/source/assets/stylesheets/components/_help-article.scss
+++ b/source/assets/stylesheets/components/_help-article.scss
@@ -2,8 +2,7 @@
   @include ordered-list;
 
   aside {
-    background: var(--background-color--tinted);
-    border-radius: var(--border-radius);
+    border-left: 0.05rem solid var(--font-color);
     font-size: var(--font-size--small);
     font-weight: var(--font-weight--body);
     margin: 0 0 var(--spacing--small);

--- a/source/assets/stylesheets/components/_signage.scss
+++ b/source/assets/stylesheets/components/_signage.scss
@@ -1,17 +1,17 @@
 $_signage-subway-line-width: 1.7em;
 
 .signage {
-  border: 0.1em solid var(--font-color);
-  border-radius: var(--border-radius);
+  background-color: $highlight-color;
   font-size: 80%;
   font-weight: var(--font-weight--bold);
   display: inline-block;
-  padding: 0.05rem 0.25rem 0;
+  padding: 0.05rem 0.15rem 0;
   text-transform: uppercase;
 }
 
 .signage--subway {
   align-items: center;
+  border: 0.1em solid var(--font-color);
   border-radius: 50%;
   display: inline-flex;
   justify-content: center;

--- a/source/assets/stylesheets/settings/_variables.scss
+++ b/source/assets/stylesheets/settings/_variables.scss
@@ -70,6 +70,9 @@
   --timing: ease;
 }
 
+// Colors
+$highlight-color: rgba(yellow, 0.1);
+
 // Breakpoints
 $breakpoint--mobile: 32rem;
 $breakpoint--desktop: 48rem;


### PR DESCRIPTION
This PR improves the hierarchy of information when reading help articles.

## After

<img width="375" alt="Screen Shot 2019-11-19 at 10 35 33" src="https://user-images.githubusercontent.com/28635708/69161017-7c117300-0ab8-11ea-9562-05604279de33.png"/>
