### PR TITLE
Add the ability to theme pages, categories

### DIFF
--- a/source/assets/stylesheets/generic/_themes.scss
+++ b/source/assets/stylesheets/generic/_themes.scss
@@ -1,0 +1,4 @@
+.themes--dark {
+  --background-color: black;
+  --font-color: whitesmoke;
+}

--- a/source/assets/stylesheets/main.css.scss
+++ b/source/assets/stylesheets/main.css.scss
@@ -7,6 +7,7 @@
 @import "tools/unordered-list";
 
 @import "generic/normalize";
+@import "generic/themes";
 
 @import "elements/buttons";
 @import "elements/forms";

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -1,5 +1,16 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html
+  lang="<%= I18n.locale %>"
+  class="
+    <% if current_article %>
+      <% if current_article.data.theme %>
+        <%= "themes--#{current_article.data.theme}" %>
+      <% else %>
+        <%= "themes--#{current_article.data.category}" %>
+      <% end %>
+    <% end %>
+    "
+>
   <head>
     <meta charset="utf-8">
     <meta name="viewport"


### PR DESCRIPTION
This PR adds the ability for a specific page or section of the website to have different themes.

A class is automatically added to every page, scoped to its category. Add a theme for a category in `themes.scss`, overriding as few or as many colors as necessary.

e.g. `.themes--help` would theme all help articles.

You can also theme individual pages by providing a `theme` key and value in the article [frontmatter].

e.g. `theme: dark` in the article frontmatter would apply a `themes--dark` class to the page.

[frontmatter]: https://middlemanapp.com/basics/frontmatter/

## Before
A page with default theme applied
![Screen Shot 2020-04-28 at 20 38 52](https://user-images.githubusercontent.com/28635708/80551205-aed96480-8990-11ea-931c-4b25e96f5a0d.png)

## After
The same page, requesting a `dark` theme in its frontmatter
![Screen Shot 2020-04-28 at 20 38 36](https://user-images.githubusercontent.com/28635708/80551214-b436af00-8990-11ea-899f-4b4d011d21bc.png)