### PR TITLE
Simplify colors

### DIFF
--- a/source/assets/stylesheets/components/_flytitle.scss
+++ b/source/assets/stylesheets/components/_flytitle.scss
@@ -1,5 +1,4 @@
 .flytitle {
-  color: var(--font-color--dimmed);
   display: flex;
   font-size: var(--font-size--small);
   font-weight: var(--font-weight--normal);

--- a/source/assets/stylesheets/components/_footer.scss
+++ b/source/assets/stylesheets/components/_footer.scss
@@ -1,5 +1,4 @@
 .footer {
-  color: var(--font-color--dimmed);
   display: flex;
   font-size: var(--font-size--small);
   justify-content: space-between;

--- a/source/assets/stylesheets/components/_help-article.scss
+++ b/source/assets/stylesheets/components/_help-article.scss
@@ -2,7 +2,7 @@
   @include ordered-list;
 
   aside {
-    border-left: 0.05rem solid var(--font-color);
+    border-left: var(--border);
     font-size: var(--font-size--small);
     font-weight: var(--font-weight--body);
     margin: 0 0 var(--spacing--half);

--- a/source/assets/stylesheets/components/_resume.scss
+++ b/source/assets/stylesheets/components/_resume.scss
@@ -61,7 +61,6 @@
 
 .resume__item {
   border-top: var(--border);
-  border-color: var(--font-color--dimmed);
   padding: var(--spacing--quarter) 0;
 
   &:first-of-type {

--- a/source/assets/stylesheets/components/_signage.scss
+++ b/source/assets/stylesheets/components/_signage.scss
@@ -1,17 +1,18 @@
 $_signage-subway-line-width: 1.7em;
 
 .signage {
-  background-color: $highlight-color;
+  background-color: var(--highlight-color);
+  border-radius: 0.1rem;
   font-size: 80%;
   font-weight: var(--font-weight--bold);
   display: inline-block;
-  padding: 0.05rem 0.15rem 0;
+  padding: 0.05rem 0.2rem 0;
   text-transform: uppercase;
 }
 
 .signage--subway {
   align-items: center;
-  border: 0.1em solid var(--font-color);
+  border: 0.1em solid var(--content-color);
   border-radius: 50%;
   display: inline-flex;
   justify-content: center;

--- a/source/assets/stylesheets/elements/_buttons.scss
+++ b/source/assets/stylesheets/elements/_buttons.scss
@@ -6,7 +6,7 @@ button,
   background-color: var(--action-color);
   border: 0;
   border-radius: var(--border-radius);
-  color: inherit;
+  color: var(--background-color);
   cursor: pointer;
   display: inline-block;
   font-family: var(--font-family-base);
@@ -27,8 +27,8 @@ button,
   }
 
   &:focus {
-    outline: var(--focus-outline);
-    outline-offset: var(--focus-outline-offset);
+    box-shadow: 0 0 0 2px #{var(--background-color)}, 0 0 0 4px #{var(--action-color)};
+    outline: none;
   }
 
   &:disabled {

--- a/source/assets/stylesheets/elements/_forms.scss
+++ b/source/assets/stylesheets/elements/_forms.scss
@@ -70,7 +70,7 @@ textarea {
   }
 
   &::placeholder {
-    color: var(--font-color);
+    color: var(--content-color);
     opacity: 0.25;
   }
 }

--- a/source/assets/stylesheets/elements/_typography.scss
+++ b/source/assets/stylesheets/elements/_typography.scss
@@ -1,5 +1,5 @@
 html {
-  color: var(--font-color);
+  color: var(--content-color);
   font-family: var(--font-family);
   font-size: 100%;
   line-height: var(--line-height);

--- a/source/assets/stylesheets/generic/_themes.scss
+++ b/source/assets/stylesheets/generic/_themes.scss
@@ -1,4 +1,5 @@
 .themes--dark {
   --background-color: black;
-  --font-color: whitesmoke;
+  --content-color: whitesmoke;
+  --content-color-rgb: 245, 245, 245;
 }

--- a/source/assets/stylesheets/settings/_variables.scss
+++ b/source/assets/stylesheets/settings/_variables.scss
@@ -1,14 +1,14 @@
 :root {
   // Colors
-  --background-color: hsl(0, 0%, 100%);
-  --background-color--tinted: hsl(0, 0%, 95%);
-  --font-color: hsl(0, 0%, 0%);
-  --font-color--dimmed: hsla(0, 0%, 60%);
+  --background-color: white;
+  --content-color: black;
+  --content-color-rgb: 0, 0, 0;
 
-  --border-color: var(--font-color--dimmed);
-  --action-color: var(--font-color);
-  --action-color--hover: var(--font-color);
-  --focus-color: var(--font-color--dimmed);
+  --action-color: var(--content-color);
+  --action-color--hover: rgba(var(--content-color-rgb), 0.75);
+  --border-color: var(--content-color);
+  --focus-color: var(--content-color);
+  --highlight-color: rgba(var(--content-color-rgb), 0.075);
 
   // Typography
   --font-family: "Lato", system-ui, sans-serif;
@@ -71,9 +71,6 @@
   --duration: 150ms;
   --timing: ease;
 }
-
-// Colors
-$highlight-color: rgba(yellow, 0.1);
 
 // Breakpoints
 $breakpoint--mobile: 32rem;


### PR DESCRIPTION
This PR simplifies color CSS custom properties and usage in the app down to two colors—for background and content. Among other benefits, this reduces the overhead required to modify/create themes.