### PR TITLE
Add video, audio embeds

### DIFF
--- a/source/assets/stylesheets/components/_mosaic.scss
+++ b/source/assets/stylesheets/components/_mosaic.scss
@@ -6,7 +6,7 @@ $_mosaic-columns: 4;
   grid-template-columns: repeat($_mosaic-columns, 1fr);
   grid-auto-rows: 4.5rem;
   grid-gap: var(--spacing--eighth);
-  margin: var(--spacing) 0;
+  margin: var(--spacing--eighth) 0;
 }
 
 .mosaic__icon {

--- a/source/assets/stylesheets/components/_mosaic.scss
+++ b/source/assets/stylesheets/components/_mosaic.scss
@@ -6,6 +6,7 @@ $_mosaic-columns: 4;
   grid-template-columns: repeat($_mosaic-columns, 1fr);
   grid-auto-rows: 4.5rem;
   grid-gap: var(--spacing--eighth);
+  margin: var(--spacing) 0;
 }
 
 .mosaic__icon {

--- a/source/assets/stylesheets/components/_soundcloud.scss
+++ b/source/assets/stylesheets/components/_soundcloud.scss
@@ -1,0 +1,5 @@
+.soundcloud {
+  background-color: #f5f5f5;
+  display: flex;
+  margin: var(--spacing--eighth) 0;
+}

--- a/source/assets/stylesheets/main.css.scss
+++ b/source/assets/stylesheets/main.css.scss
@@ -16,6 +16,7 @@
 @import "elements/tables";
 @import "elements/typography";
 
+@import "objects/aspect-ratio";
 @import "objects/rack";
 @import "objects/section";
 @import "objects/site";

--- a/source/assets/stylesheets/main.css.scss
+++ b/source/assets/stylesheets/main.css.scss
@@ -39,5 +39,6 @@
 @import "components/mosaic";
 @import "components/sidenote";
 @import "components/signage";
+@import "components/soundcloud";
 
 @import "utilities/u-link";

--- a/source/assets/stylesheets/objects/_aspect-ratio.scss
+++ b/source/assets/stylesheets/objects/_aspect-ratio.scss
@@ -1,0 +1,17 @@
+.aspect-ratio {
+  height: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.aspect-ratio--widescreen {
+  padding-top: percentage(9/16);
+}
+
+.aspect-ratio__content {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}

--- a/source/assets/stylesheets/pages/_play.scss
+++ b/source/assets/stylesheets/pages/_play.scss
@@ -7,7 +7,7 @@
     letter-spacing: var(--letter-spacing--loose);
     margin-bottom: var(--spacing--half);
     margin-top: var(--spacing--double);
-    padding-bottom: var(--spacing--half);
+    padding: var(--spacing--half) 0;
     text-transform: uppercase;
   }
 }

--- a/source/layouts/play.erb
+++ b/source/layouts/play.erb
@@ -25,35 +25,7 @@
       <% end %>
 
       <%= partial "plays/actions" %>
-    </section>
 
-    <% if current_page.data.productions.present? %>
-      <section class="section__content section__content--slim">
-        <h2>
-          Production
-        </h2>
-
-        <div class="stack">
-          <% current_page.data.productions.each_with_index do |production, index| %>
-            <%= partial "plays/production", locals: { production: production, index: index } %>
-          <% end %>
-        </div>
-      </section>
-    <% end %>
-
-    <% if current_page.data.quotes.present? %>
-      <section class="section__content section__content--slim">
-        <h2>
-          Reception
-        </h2>
-
-        <% current_page.data.quotes.each do |quote| %>
-          <%= partial "plays/quote", locals: { quote: quote } %>
-        <% end %>
-      </section>
-    <% end %>
-
-    <section class="section__content section__content--slim">
       <%= yield %>
     </section>
   </article>

--- a/source/partials/_soundcloud.erb
+++ b/source/partials/_soundcloud.erb
@@ -1,0 +1,11 @@
+<div class="soundcloud">
+  <iframe
+    width="100%"
+    height="166"
+    scrolling="no"
+    frameborder="no"
+    allow="autoplay"
+    src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/<%= track_id %>&color=%23<%= color_hex %>&auto_play=false&hide_related=true&show_comments=false&show_user=false&show_reposts=false&show_teaser=false"
+  >
+  </iframe>
+</div>

--- a/source/partials/_youtube.erb
+++ b/source/partials/_youtube.erb
@@ -3,7 +3,7 @@
     class="aspect-ratio__content"
     width="640"
     height="360"
-    src="<%= video_url %>"
+    src="https://www.youtube.com/embed/<%= video_id %>"
     frameborder="0"
     allow="accelerometer; encrypted-media; gyroscope"
     allowfullscreen

--- a/source/partials/_youtube.erb
+++ b/source/partials/_youtube.erb
@@ -1,0 +1,12 @@
+<div class="aspect-ratio aspect-ratio--widescreen">
+  <iframe
+    class="aspect-ratio__content"
+    width="640"
+    height="360"
+    src="<%= video_url %>"
+    frameborder="0"
+    allow="accelerometer; encrypted-media; gyroscope"
+    allowfullscreen
+  >
+  </iframe>
+</div>

--- a/source/plays/_productions.erb
+++ b/source/plays/_productions.erb
@@ -1,0 +1,9 @@
+<h2>
+  Production
+</h2>
+
+<div class="stack">
+  <% current_page.data.productions.each_with_index do |production, index| %>
+    <%= partial "plays/production", locals: { production: production, index: index } %>
+  <% end %>
+</div>

--- a/source/plays/_quotes.erb
+++ b/source/plays/_quotes.erb
@@ -1,0 +1,7 @@
+<h2>
+  Reception
+</h2>
+
+<% current_page.data.quotes.each do |quote| %>
+  <%= partial "plays/quote", locals: { quote: quote } %>
+<% end %>

--- a/source/plays/_synopsis.erb
+++ b/source/plays/_synopsis.erb
@@ -1,0 +1,7 @@
+<h2>
+  Synopsis
+</h2>
+
+<p>
+  <%= current_page.data.synopsis %>
+</p>

--- a/source/plays/mr-and-mrs-blacke.html.erb
+++ b/source/plays/mr-and-mrs-blacke.html.erb
@@ -42,6 +42,8 @@ quotes:
     quote: A crowning achievement in Caribbean theatre.
 ---
 
+<%= partial "plays/productions" %>
+
 <%= partial(
   "partials/gallery",
   locals: {
@@ -67,6 +69,8 @@ quotes:
     ],
   }
 ) %>
+
+<%= partial "plays/quotes" %>
 
 <%= partial(
   "partials/youtube",

--- a/source/plays/mr-and-mrs-blacke.html.erb
+++ b/source/plays/mr-and-mrs-blacke.html.erb
@@ -6,6 +6,11 @@ theme: mr-and-mrs-blacke
 email_title: Mr and Mrs Blacke
 hero_image_description: "Sakina Deer and Keiran King perform a scene from 'Mr & Mrs Blacke'"
 logline: A young, attractive couple with every success discover that their lifestyle — and their marriage — is built on secrets and deceptions.
+synopsis: Nicholas and Samantha are an upwardly-mobile Jamaican couple — he an
+  ambitious junior exec, she an over-educated housewife. Over the course of an
+  evening, with Nicholas up against a major deadline and a friend's pregnancy
+  unsettling Samantha, they find it increasingly difficult to paper over their
+  problems.
 
 cast_size: 1f, 1m
 duration_in_minutes: 80
@@ -41,6 +46,8 @@ quotes:
   - author: Sean Nottage
     quote: A crowning achievement in Caribbean theatre.
 ---
+
+<%= partial "plays/synopsis" %>
 
 <%= partial "plays/productions" %>
 

--- a/source/plays/mr-and-mrs-blacke.html.erb
+++ b/source/plays/mr-and-mrs-blacke.html.erb
@@ -65,5 +65,10 @@ quotes:
       "production/the-couple-embrace.jpg",
       "production/nicholas-wins.jpg",
     ],
-  },
+  }
+) %>
+
+<%= partial(
+  "partials/youtube",
+  locals: { video_url: "https://www.youtube.com/embed/n-U8JvOEROw" }
 ) %>

--- a/source/plays/mr-and-mrs-blacke.html.erb
+++ b/source/plays/mr-and-mrs-blacke.html.erb
@@ -45,6 +45,11 @@ quotes:
 <%= partial "plays/productions" %>
 
 <%= partial(
+  "partials/soundcloud",
+  locals: { color_hex: "121212", track_id: 197675517 }
+) %>
+
+<%= partial(
   "partials/gallery",
   locals: {
     image_paths: [
@@ -66,13 +71,13 @@ quotes:
       "production/samantha-gives-nicholas-flowers.jpg",
       "production/the-couple-embrace.jpg",
       "production/nicholas-wins.jpg",
-    ],
+    ]
   }
 ) %>
 
-<%= partial "plays/quotes" %>
-
 <%= partial(
   "partials/youtube",
-  locals: { video_url: "https://www.youtube.com/embed/n-U8JvOEROw" }
+  locals: { video_id: "n-U8JvOEROw" }
 ) %>
+
+<%= partial "plays/quotes" %>


### PR DESCRIPTION
## Problem
Visitors cannot watch videos or listen to audio associated with plays.

## Solution
This PR adds the ability to embed YouTube videos and Soundcloud audio tracks on the site.

## After

### Mobile

<img width="375" alt="Screen Shot 2020-07-03 at 16 00 30" src="https://user-images.githubusercontent.com/28635708/86495370-19b76b00-bd47-11ea-8767-a7016cc81dbf.png">

### Desktop

![Screen Shot 2020-07-03 at 16 00 08](https://user-images.githubusercontent.com/28635708/86495368-18863e00-bd47-11ea-843e-cff426709378.png)