### PR TITLE
Fit portrait images in lightbox

### DIFF
--- a/source/assets/stylesheets/components/_lightbox.scss
+++ b/source/assets/stylesheets/components/_lightbox.scss
@@ -9,7 +9,7 @@ $_lightbox-z-index: 100;
   background-color: rgba(var(--lightbox-background-color-rgb), 0.85);
   display: grid;
   grid-template-areas: "fullscreen";
-  height: 100%;
+  height: 100vh;
   justify-items: center;
   left: 0;
   position: fixed;
@@ -46,8 +46,8 @@ $_lightbox-z-index: 100;
 .lightbox__image {
   grid-area: fullscreen;
   height: auto;
-  max-height: 90%;
-  max-width: 90%;
+  max-height: 90vh;
+  max-width: 90vw;
   width: auto;
 }
 
@@ -57,7 +57,7 @@ $_lightbox-z-index: 100;
   grid-template-columns: max-content auto max-content;
   grid-area: fullscreen;
   line-height: 0;
-  width: 85%;
+  width: 85vw;
 }
 
 .lightbox__next {


### PR DESCRIPTION
## Problem
When browsing images in a lightbox, portrait images bleed off-screen and navigation controls jump to different positions.

## Solution
This PR refactors `lightbox`es to use viewport units instead of percentages.

## Before
<img width="1430" alt="Screen Shot 2020-07-03 at 10 39 25 PM" src="https://user-images.githubusercontent.com/28635708/86503687-61a5b480-bd7e-11ea-8d0b-018f6fc162d7.png">

## After
<img width="1430" alt="Screen Shot 2020-07-03 at 10 38 38 PM" src="https://user-images.githubusercontent.com/28635708/86503685-5fdbf100-bd7e-11ea-9e42-65126b59d678.png">