### PR TITLE
Improve inline lists

### DIFF
--- a/source/assets/stylesheets/components/_inline-list.scss
+++ b/source/assets/stylesheets/components/_inline-list.scss
@@ -1,12 +1,10 @@
 .inline-list {
-  display: flex;
-}
+  * {
+    display: inline;
+  }
 
-.inline-list__item {
-  display: flex;
-  
-  & + &::before {
+  * + *::before {
     content: "·";
-    margin: 0 var(--spacing--quarter);
+    margin: 0 var(--spacing--eighth);
   }
 }

--- a/source/layouts/opinion.erb
+++ b/source/layouts/opinion.erb
@@ -12,12 +12,12 @@
       </h1>
 
       <p class="fine-print inline-list">
-        <span class="inline-list__item">
+        <span>
           <%= reading_time_in_minutes(current_article.body) %> min read
         </span>
 
         <% date = date_to_s(current_article.data.publication_date) %>
-        <span class="inline-list__item">
+        <span>
           <%= link_to(
             "published in #{current_article.data.publication} on&nbsp;#{date}",
             current_article.data.publication_url,

--- a/source/layouts/review.erb
+++ b/source/layouts/review.erb
@@ -10,12 +10,12 @@
       </h1>
 
       <p class="fine-print inline-list">
-        <span class="inline-list__item">
+        <span>
           <%= reading_time_in_minutes(current_article.body) %> min read
         </span>
 
         <% date = date_to_s(current_article.data.publication_date) %>
-        <span class="inline-list__item">
+        <span>
           <%= link_to(
             "published in #{current_article.data.publication} on&nbsp;#{date}",
             current_article.data.publication_url,

--- a/source/plays/_script-stats.erb
+++ b/source/plays/_script-stats.erb
@@ -1,16 +1,16 @@
-<ul class="inline-list fine-print">
+<ul class="fine-print inline-list">
   <% if current_page.data.genre.present? && current_page.data.structure.present? %>
-    <li class="inline-list__item">
+    <li>
       <%= "A #{current_page.data.genre} in #{current_page.data.structure}" %>
     </li>
   <% end %>
   <% if current_page.data.duration_in_minutes.present? %>
-    <li class="inline-list__item">
+    <li>
       <%= current_page.data.duration_in_minutes %> min
     </li>
   <% end %>
   <% if current_page.data.cast_size.present? %>
-    <li class="inline-list__item">
+    <li>
       <%= current_page.data.cast_size %>
     </li>
   <% end %>


### PR DESCRIPTION
## Problem
Inline lists are hard to read on small screens, with an unclear path for the eye to follow.

## Solution
This commit refactors inline lists to be more readable on small screens, and more concise in usage.

## Before/After
![b:a inline lists](https://user-images.githubusercontent.com/28635708/92971891-4d052d00-f44f-11ea-84fc-c0d1cb595ad4.jpg)
