### PR TITLE
Restore play typography

### DIFF
--- a/source/assets/stylesheets/pages/_play.scss
+++ b/source/assets/stylesheets/pages/_play.scss
@@ -1,14 +1,18 @@
 .play {
-  font-weight: var(--font-weight--body);
+  font-weight: var(--font-weight--light);
 
   h2 {
     border-bottom: var(--border);
-    font-weight: var(--font-weight--body);
+    font-weight: var(--font-weight--light);
     letter-spacing: var(--letter-spacing--loose);
     margin-bottom: var(--spacing--half);
     margin-top: var(--spacing--double);
     padding: var(--spacing--half) 0;
     text-transform: uppercase;
+  }
+
+  p {
+    font-weight: var(--font-weight--light);
   }
 }
 


### PR DESCRIPTION
This commit restores lighter typography to play pages. An older commit (518e448aa5c5082c2b6b5ef7654afc33a512c72a) made sitewide text heavier to improve legibility.

## Before/After
![b:a play typography](https://user-images.githubusercontent.com/28635708/92972468-5347d900-f450-11ea-85f0-9add3cc095f4.jpg)
