### PR TITLE
View external content

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -27,6 +27,7 @@ set :markdown,
 set :markdown_engine, :redcarpet
 
 page "articles/christmas/*", layout: :christmas
+page "articles/external/*", layout: :external
 page "articles/opinions/*", layout: :opinion
 page "articles/film-reviews/*", layout: :review
 page "articles/theatre-reviews/*", layout: :review

--- a/source/articles/external/a-riveting-mr-and-mrs-blacke.html.md
+++ b/source/articles/external/a-riveting-mr-and-mrs-blacke.html.md
@@ -1,0 +1,75 @@
+---
+title: A riveting Mr & Mrs Blacke
+date: 2012-07-22 00:00 UTC
+
+author: Marcia Rowe
+source: The Jamaica Gleaner
+source_url: http://jamaica-gleaner.com/gleaner/20120722/ent/ent5.html
+---
+
+In his latest venture, Mr & Mrs Blacke, Keiran King tackles the issue of
+marriage and just how easy it is to have it all slip through your fingers.
+
+Last Sunday, when the curtains at the Sir Philip Sherlock Centre, located on
+the Mona campus of the University of the West Indies, opened, it revealed
+35-year-old Samantha Blacke (Keisha Patterson).
+
+Motionless, she stands looking through a window of her predominantly white,
+spacious and expensively decorated apartment.
+
+She is wearing full black, comprising of a pair of shorts and blouse.
+
+Her open-space, living/dining room with an adjoining kitchen, as well as a
+half-bathroom located in the upstage area, create a distinct contrast to her
+attire.
+
+Disconcerting was the obvious untidiness of the luxurious apartment.
+
+Thereafter, her husband Nicholas Blacke (Keiran King) arrives. He too is
+attired in mainly black - a black suit with white shirt and black tie. Shortly
+after his arrival, the pieces in the puzzle of their story begin to connect
+in a slow simmering sort of way.
+
+Connected together, the puzzle revealed that the Blackes are of the "upwardly
+mobile professional class". They have been married for 10 years.
+
+Nicholas, who works for a financial investment company, is the active
+professional. He, however, does not love his job. Samantha, who wants to be a
+professional writer, seems more content to speak in poetic language than to
+put pen to paper. Rather than working on her craft, she has opted to spend
+her days at the gym and at beauty salons.
+
+Like her best friend Gina, who is never seen, Samantha wants to be a mother,
+but Nicholas is not ready to be a father.
+
+He is more concerned with maintaining the lifestyle he has worked tirelessly
+to build.
+
+His other interest seemed to be to stay on good terms with his former boss
+Natalie Wynter. She is never seen but is often the topic of heated dispute
+between Samantha and Nicholas.
+
+The subsequent firestorm grows out of control, when Nicholas and Samantha
+share a dance. The dance was, in part, an attempt to rekindle the flame in
+their marriage. But instead, everything goes terribly wrong.
+
+The story occurs in one evening, the action takes place in one location and
+the characters behave in ways based on their sex, and status.
+
+King skilfully plays with the lines of the characters, making them
+well-rounded. In so doing, the playwright suggests he understands the
+'humanness' of a person.
+
+The play was well cast. The lanky King and the short Patterson together
+produced some humorous moments. And King gave a brilliant account of Mr
+Blacke. Each change in emotions was executed with deep feelings and clarity.
+
+Similarly good was Patterson in her role as Mrs Blacke.
+
+The play is directed by Paul Issa. There were moments of wonderful blockings.
+His use of exits and entrances were clear and well defined. He fully utilised
+all the acting areas too. But the use of face towels for Samantha's clothes
+seemed contradicting to the comfortable lifestyle of the couple.
+
+Mr & Mrs Blacke is a wonderfully produced play and is worth seeing. But alas
+due to its adult content and language it is not suitable for children.

--- a/source/articles/external/final-weekend-for-two-brilliant-plays.html.md
+++ b/source/articles/external/final-weekend-for-two-brilliant-plays.html.md
@@ -1,0 +1,144 @@
+---
+title: Final weekend for two brilliant plays
+date: 2012-08-18 00:00 UTC
+
+author: Barbara Blake Hannah
+source: The Jamaica Gleaner
+source_url: http://jamaica-gleaner.com/gleaner/20120818/ent/ent2.html
+---
+
+Jamaica is a country of contrasts, carved out by its history as a former
+slave plantation and British colony. It is mere divine co-incidence that in
+this Jamaica50 year celebrating the start of the 'new Jamaica', two plays
+currently running in Kingston demonstrate very accurately, the development of
+the nation from the start of the struggle for freedom, to the Jamaica of today,
+showing the difference between uptown and downtown, rich and poor, two studies
+in Black and Blacke.
+
+Mr & Mrs Blacke is set in the uptown St Andrew world of gated communities and
+three-bedroom townhouses with designer décor, where a stay-at-home wife and her
+investment broker husband battle verbally to define their marriage and secure
+their financial goals.
+
+Mr and Mrs Blacke are obsessed with wealth. Mr Blacke is anxious to seal a
+deal with a former boss that will earn him millions, but Mrs Blacke is jealous
+of the former boss - a woman, and suspects the deal and the relationship. As
+the viability of the deal is questioned, the foundation of the childless
+relationship frays and the quarrel that has been simmering under their
+10-year-old marriage erupts into a fight that opens old wounds. Mr Blacke
+throws Mrs Blacke out of the house, she returns defiantly and then - no, I
+won't spoil the ending.
+
+Stanley, Fay, Pularchie & P takes place nearly a century ago in a downtown
+Kingston tenement yard, at a time when poor Jamaican workers were beginning to
+protest slave wages in a series of island-wide strikes and riots that gave
+birth to the modern trade-union movement.
+
+The play was written by the late Gloria Lannaman with a central theme of the
+labour unrest of the 1930s. The playwright uses this period of Jamaica's
+history to weave a tale of the life and human condition of the black working
+class of that time, and the significant political and social developments that
+led to the Jamaica of today.
+
+Stanley, a wharf worker who lives with and loves Fay, is agitating the other
+workers to demand a raise in their wages from nine pence to one shilling an
+hour - a surprisingly princely sum to Joey, the country-bumpkin-come-to-town
+who earns nine pence a day as a farm manager!
+
+Stanley's efforts to persuade the workers to join his demands for more pay are
+resisted by Silas, who says workers cannot win against management when there
+is so much willing, free labour. Stanley's efforts to mobilise the workers
+causes him to lose his job, then as rioting begins in the street, Silas is
+killed and Stanley is framed for his murder. To escape, he must- no I won't
+spoil the ending either.
+
+
+Seeing these two plays one night after the other was an unusual experience of
+social contrasts for me. In two nights of good theatre, Jamaica takes an
+astonishing leap from yesterday to today. You get the feeling that if the
+characters in either play met each other in real life, neither would recognise
+nor acknowledge the reality of the other.
+
+No one in 1938 could have believed that their grandchildren could have left the
+ghetto so spectacularly as the two uptowners in their pristine white townhouse.
+Nor could the two uptowners accustomed to their smartphones, gym appointments
+and expensive lunch dates - ever believe they came from the humble beginnings
+of Stanley and Fay's yard, though in fact, we all came from there in one way
+or other.
+
+Compared with the pathos and emotion of Stanley and Fay, Mr and Mrs Blacke's
+marital strife seems trivial and even amusing. But it is as real a picture of
+the economic lives that fashion Jamaica today. This is no less true of Stanley
+and Fay in yesterday's Jamaica.
+
+In fact, it is so uncanny how similar both couples are, that both plays should
+be a compulsory double-bill presentation for all Jamaica to see.
+
+
+What both plays have in common are some stellar performances, rarely seen on a
+Jamaican stage. Mr & Mrs Blacke has only two actors, Keiran King, the first, is
+not just a good actor, believable in the role, but he also wrote the play and
+produced it. He and Keisha Patterson - a perfect portrayal of female yuppie
+hysteria occupy the stage throughout the entire play in a perfectly coordinated
+dialogue that ranges through all emotions that expose the highs and lows of
+their relationship with keen acting talent.
+
+The story of the yuppie couple gives a telling (and perhaps accurate) glimpse
+of the life, interests and aspirations of those behind the gated walls of
+'uptown' and the play is a tour-de-force of acting, as well as a well-written
+story not often seen in Jamaican theatre.
+
+The surprising ending adds up, but it's a story we hope isn't fully over,
+perhaps a sequel - as it was such a pleasure.
+
+Director Paul Issa moves his actors effortlessly across the stage, giving them
+dramatic action and pacing that makes the play a delight to enjoy. He says he
+worked hard to present the characters truthfully, without passing judgement on
+their flawed but human natures. The producers, Eight Seven Six, whose brochure
+states that they 'set their standards high', presented an exceptionally
+beautiful set that gave an accurate setting for the drama, including an outdoor
+garden with plants on which 'rain' falls very realistically in one part of the
+play.
+
+Set design is again a beautiful feature of the Stanley and Faye set, this time
+the brick and board, zinc roofs of a downtown yard are spread across the stage.
+At one side the walls of one house disappear in a scene change to reveal a
+bedroom in another part of town, while in another scene a very realistic
+'country truck' bumps and jolts the comic relief couple, Joey and Doris,
+towards the country. The audience was in awe of the set changes which were
+quick and quiet.
+
+The players are each excellent. Dennis Titus as Stanley shines in his role as
+the labour leader, with Sherando Ferril as his girlfriend Fay. Maurice Bryan
+plays Stanley's friend Nathan who joins him, while veteran actor Carl Davis
+plays Silas who does not support the cause. Marguerite Newland plays Miss
+Pularchie, matron of the yard and mother of Doris, and actually played the
+role of Doris in the original staging of the play in 1974. Special mention
+must be made of Donald 'Iceman' Anderson who played 'Joey' with a unique
+comedic talent that made his scenes memorable.
+
+Director Pablo Hoilet can be proud of his work. This was a class production.
+
+Stanley and Fay was a great reminder of days gone by. The language so carefully
+researched by writer Lannaman, caused us to laugh to hear it. Remember
+'chuppence' (Threepence) or 'grip' (small suitcase)'? 'Whe' yu ben dey?'
+(Where were you?) caused the loudest laugh of the night.
+
+But more than the laughs, was the opportunity to be reminded of what our
+forefathers endured to win full freedoms from slavery, through the struggle of
+the 1938 workers.
+
+It's a battle worth remembering, as we celebrate 50 years of an Independent
+Jamaica. Congrats to producers Marjorie Whylie and Pauline Stone-Myrie, who
+played Fay and Ms Pularchie in the original production.
+
+
+Overall, these two plays show that Jamaican theatre still has moments of
+excellence, amidst the popular camaraderie that graces our stages. I encourage
+productions to have a film record made of these theatrical gems, so that
+generations to come may have the opportunity shared by a few adventurous
+theatre-goers who value live, high quality entertainment.
+
+Mr & Mrs Blacke is being played at the Philip Sherlock Centre, University of
+the West Indies, while Stanley Faye, Pularchie & P is being held at Theatre
+Place, Haining Road.

--- a/source/articles/external/for-better-or-worse-king-tackles-love-marriage-and-class-with-latest-effort.html.md
+++ b/source/articles/external/for-better-or-worse-king-tackles-love-marriage-and-class-with-latest-effort.html.md
@@ -1,0 +1,50 @@
+---
+title: For better or worse — King tackles love, marriage and class with latest effort
+date: 2012-06-19 00:00 UTC
+
+author: Tyrone Reid
+source: Tallawah
+source_url: http://www.tallawahmagazine.com/2012/06/for-better-or-worse-king-tackles-love.html
+---
+
+Sometime last year, while promoting the period piece Last Call, writer-actor
+Keiran King mentioned to TALLAWAH that he was working on a marriage drama
+scheduled to premiere in the summer of 2012 under the auspices of his company,
+Eight Seven Six. As it turns out, that work is the forthcoming Mr & Mrs Blacke,
+which is set to open at UWI’s Philip Sherlock Centre in the middle of next
+month.
+
+With the award-winning Last Call (also his directorial debut) King showed a
+remarkable gift for elucidating the fragile humanity at the heart of intimate
+relationships and platonic friendships. With Blacke, he appears poised to
+expose yet another startling dimension to his obviously huge talents.
+
+Chronicling an evening in the life of the titular, well-to-do young couple
+(King and Keisha Patterson), the play is, from what I’ve managed to glean,
+part revealing character study, part exposé on societal hypocrisy, class, and
+that noble institution called matrimony.
+
+Even so, what made King decide to write about marriage this time around? He
+laughs. “Well, certainly, it’s one of the universal topics. But I felt that the
+fears, the aspirations, the hopes and dreams and prejudices of the middle-class
+and the upper middle-class in Jamaica are not really represented on the stage,”
+he confesses during a recent interview at their rehearsal warehouse off South
+Camp Road in Kingston. “And so I wanted to throw those kinds of characters on
+the stage and see what happens inside their house.”
+
+The premise smacks of something out of Edward Albee or Noel Coward. And it’s
+little wonder, given that the gangly King fancies himself a student of the
+masters and a thespian with exquisite tastes. Mr & Mrs Blacke, he notes, will
+both provoke thought and entertain people’s socks off, in spite of its
+miniscule cast.
+
+“It’s entirely two people, and it’s played out in real time, an evening in
+their house. And the idea is that on the outside they look like the perfect
+Jamaican couple,” says King, who tapped Paul Issa to direct. “They look like
+the couple that everyone thinks that they want to be.”
+
+Out of sheer curiosity I ask, Should audiences expect a story with a twist?
+“(Laughs) Well, I don’t know if it has a twist, but even though [the couple]
+looks perfect on the outside, what [the audience] sees is what’s behind the
+curtain, so to speak,” he points out. “You see the reality of what takes
+place inside their house.”

--- a/source/articles/external/index.html.erb
+++ b/source/articles/external/index.html.erb
@@ -1,0 +1,14 @@
+---
+date: 2020-09-01 00:00 UTC
+layout: page
+---
+
+<h1>External Content</h1>
+
+<ul>
+  <% current_page.children.each do |article| %>
+    <li>
+      <%= link_to article.title, article %>
+    </li>
+  <% end %>
+</ul>

--- a/source/articles/external/marriage-interrupted.html.md
+++ b/source/articles/external/marriage-interrupted.html.md
@@ -1,0 +1,47 @@
+---
+title: Marriage interrupted
+date: 2012-08-19 00:00 UTC
+
+author: Owen Tomlinson
+source: The Jamaica Observer
+source_url: http://www.jamaicaobserver.com/entertainment/marriage-interrupted_12309387
+---
+
+Nicholas and Samantha Blacke seem a picture-perfect couple: attractive,
+intelligent, and live in a townhouse in a gated complex. The Blackes are the
+epitome of upward mobility. But beneath the polished exterior, the pair is
+anything but happily married. Miserably existing is an apt summation to their
+now hapless union.
+
+It’s the somewhat engaging premise of Mr and Mrs Blacke, actor and playwright
+Keiran King’s theatrical production, now playing at Philip Sherlock Centre for
+the Creative Arts, University of the West Indies, Mona campus.
+
+King casts himself as the sardonic Nicholas Blacke, in the Paul Issa-directed
+play, while songbird and actress Keisha Patterson easily slips into the role of
+his creatively frustrated and emotionally weary spouse.
+
+The two are competent thespians, and riff well off each other in the two-hander
+play’s quest to examine the whens, whys, and hows of a derailing marriage. The
+lanky King, exceedingly better as a writer than an actor, has a gift with
+crafting witty dialogue, and incisive conversation. While King efficiently
+handles his play’s zingy one-liners with a relaxed relish, he’s unable to
+convey the dramatic heft when the role demands it. Case in point: a
+confrontational scene between the spouses sees King screeching more than
+emoting, and try as he does to find an emotional centre for Nicholas, his
+character comes across as more whiny than whipsmart.
+
+For her part, Patterson breathes some needed moxie into the not-so-likable
+Samantha, giving it her all. But the self-absorption of her character is
+limiting and allows her little leeway to dig deeper.
+
+Through both King’s script and Issa’s subtle directorial nuances, Mr and Mrs
+Blacke works best when it shows the inner thoughts and workings of the upper
+middle class life. There, it excels.
+
+The set — the Blacke’s townhouse, a stark minimalist white — also deserves
+kudos, as it effectively plays as a visual contrast to both the Blacke name
+and the black hole into which the once-happy union has sunk.
+
+See the play for a fresh, intelligent take on marital strife. Just don’t expect
+to love it all. But perhaps that was King’s intention.

--- a/source/articles/external/mr-and-mrs-blacke-a-drama-in-black-and-white.html.md
+++ b/source/articles/external/mr-and-mrs-blacke-a-drama-in-black-and-white.html.md
@@ -1,0 +1,107 @@
+---
+title: Mr & Mrs Blacke — a drama in black and white
+date: 2012-07-13 00:00 UTC
+
+author: Ryan Smith
+source: Susumba
+source_url: http://www.susumba.com/theatre/news/mr-and-mrs-blacke-drama-black-and-white
+---
+
+A huge part of a production is its style, the producer's director's and set
+designer's. combining their creativity to create the the world and enhance
+the meaning of the production. The relatively new production company Eight
+Seven Six has made style their calling card. Their newest production Mr and
+Mrs Blacke is no different.
+
+Mr and Mrs. Blacke is a drama in black and white which are the only two
+colors employed in the play. Keiran King, writer producer and actor in Mr and
+Mrs. Blacke explains that the colors are an important part of translating
+meaning as it represent the polarized world of the couple. “You want every
+part of your production to tell the story that you want to tell,” King says.
+“Sets and costumes have their own language that provides clues to the story,”
+he says. “Their world has become a world of black and white,” he says.
+
+Mr. and Mrs. Blacke stars King alongside Keisha Patterson and is directed by
+Paul Issa. The play surrounds a upper-middle class couple, Mr. and Mrs. Blacke,
+who appear to be perfect with all the requisite trappings of a townhouse on
+the right hill, a good car, youth and good looks. “It’s really to take the
+perfect upper middle-class couple and expose their fears and neuroses.” King
+explains that through the couple, the play explores class, race, power and the
+way the couple relates to the rest of the island.
+
+Of course while working with black and white might produce a vey sexy look and
+feel the colour restriction comes with severe limitations. “You’d be surprised
+how difficult that is because the world is in beautiful technicolour,” he says.
+Sourcing props was therefore a great challenge and in some cases they had to
+request of their partners that the products being placed in the production be
+converted to black and white.
+
+“When you restrict the colour palette one of the things that becomes very
+important is texture,” King points out. He notes that lighting is also
+important as light and shadow brings depth and demarcate objects. According to
+King, set designer Patrick Williams has therefore been critical to translating
+these restrictions into architectural decisions.
+
+Along with the colour, the style and quality of the clothing is also critical
+in order to achieve authenticity. To realize this, Eight Seven Six has
+partnered with Spokes Apparel and Heather Laine to produce custom made clothing
+for the characters.
+
+King argues that Mr. and Mrs. Blacke contends with issues relevant to
+contemporary Jamaica. “The play is very Jamaican,” he says. “It deals with
+where Jamaica is right now. It just doesn’t drape itself in gold green and
+black.”
+
+“I think I’m the only playwright who hasn’t fallen into a bucket of patriotism
+this year,” he says. He notes however that the absence of overt references to
+Jamaica 50 does not reflect an absence of patriotism. “I love my county so
+much that I actually believe in her.” he says. King argues that his belief
+that Jamaica can achieve great things fuels his thrust toward producing
+theatre with first world aesthetics with no need to apologize for an absence
+of money or resources. “I absolutely refuse to make those apologies” he says.
+
+Describing himself as committed to achieving impossibly high standards in
+aesthetics, King remarks that he began Eight Seven Six out of a desire and a
+belief that we could do better. "I didn’t want to have a company,” he says,
+“all I ever wanted to do was write plays.”
+
+King contends however that once he realized that were he to write a play and
+hand it over to one of the island’s existing producers he would be dissatisfied
+with the result, starting his own production company was inevitable.
+
+“Having foisted a company up on myself, it’s been a very exhilarating
+experience overall,” he confesses. Eight Seven Six produced its first play
+Last Call written and directed by King and co-produced by King and Scarlett
+Beharie. Last Call was highly commended for its production values. “I think
+the production quality that we achieved is something that the patrons were
+hungry for,” he says.
+
+“Theatre is on life support in this country and the life support machine is
+the benefit model.” King argues that as most productions earn by selling
+benefits the result has been that the average theatre goer is supporting a
+charity or cause and merely get to see the play as a bonus. He argues that
+this has resulted in a malaise as the audience is therefore not influencing
+greater levels of dynamism on the stage.
+
+“Our theatre space is not hungry for new ideas because it doesn’t need to be,”
+he says. King argues that although Eight Seven Six is using benefits as a part
+of its income stream the company hopes to wean itself from them in a few years.
+As such, the company is marketing heavily to the direct consumer and King sees
+movies, television and other forms of entertainment as his direct competitors
+not other plays. “We’re trying to get people not to go see the Avenges but to
+come and see us instead,” he asserts.
+
+While that is a very tall order, King seems confident that it can be achieved
+with the right marketing strategy and compelling advertising material. The
+production has therefore using billboards and other outdoor signage as well as
+life-size cutouts in pharmacies and in the cinema. “We have to find the young
+people where they are and advertise to them,” he says.
+
+“What we’re attempting in nothing less than a complete revision of the way
+Jamaican theatre is made, consumed and marketed,” he said. King argues that
+contemporary Jamaicans are not influenced by the theatre and therefore it has
+lost its role as a cultural force. “It would be nice if Jamaican theatre would
+worm its way back into people’s minds,” he says.
+
+Mr. and Mrs. Blacke opens on July 13 at the Phillip Sherlock Centre for the
+Creative Arts.

--- a/source/articles/external/mr-and-mrs-blacke-more-style-than-substance.html.md
+++ b/source/articles/external/mr-and-mrs-blacke-more-style-than-substance.html.md
@@ -1,0 +1,70 @@
+---
+title: Mr & Mrs Blacke — more style than substance
+date: 2012-08-10 00:00 UTC
+
+author: Tanya Batson-Savage
+source: Susumba
+source_url: http://susumba.com/theatre/reviews/mr-and-mrs-blacke-more-style-substance
+---
+
+Mr and Mrs Blacke, written by Keiran King and produced by Eight Seven Six, has
+more to offer in style than in substance. The play is ambitious and strives to
+be a telling commentary on Jamaica’s upper middle class. Bouyed by King’s wit
+it is amusing but it fails to deliver lasting emotional impact.
+
+Mr and Mrs Blacke is directed by Paul Issa and features Keisha Patterson and
+Keiran King as Samantha and Nicholas Blacke. The Blackes are an upper-middle
+class couple who on the outside appear happy enough, however they are at the
+point in their marriage where each is involved in his or her own life and
+disinterest has set in. Samantha has desires of living a more creative life
+though she doesn’t seem to be doing much about it and instead carries on a
+vapid existence. Nicholas is arrogant and sarcastic and making money is his
+major concern.
+
+As with Eight Seven Six’ first production, Last Call, which earned the 2011
+Actor Boy Award for Best Production, Mr and Mrs Blacke is visually appealing.
+The set is almost completely white and is striking in its starkness and
+adequately reflecting the emotionlessness of the Blacke marriage. The
+contrasting black accents and costumes complete the impression that theirs is
+a polarized world. However, Samantha’s red scarf at the end of the play gets
+a little too heavy-handed with the symbolism.
+
+The play also manages the rare feat of taking place in real time, with no
+intermission, which is refreshingly different. Lighting, designed by Nadia
+Roxburgh, looks deceptively simple. It is however quite commendable for
+keeping the cast from being lost in all the whiteness.
+
+The script largely relies on dry witty humour and is reminiscent of the and
+quippy dialogue of classic Hollywood with jokes particularly reminiscent of
+The Court Jester and Gigi, but with a touch of George Bernard Shaw. The result
+is amusing but it smacks of literary masturbation, being obviously pleased with
+how witty it is, and how good it is at referencing Shakespeare.
+
+So, although the dialogue is interesting, where Mr and Mrs Blacke starts to
+lose ground is in the script. Patterson and King both deliver decent
+performances and while they achieve some emotional depth and nuance neither
+have the strength to rescue it. Though they are a mildly interesting couple
+at the end of the play we do not truly care for them. Their passion fails to
+ignite and so when their disinterest and malaise turns to anger, it is not
+enough.
+
+Despite the humour, Mr and Mrs Blacke is a dark play. As Samantha and Nick
+spiral down a dark path on what started out as a very ordinary evening in
+their very ordinary lives, the play comments on the illusion of normalcy and
+who two people who seemed to love each other can become twisted by jealousy,
+mistrust and the constant pursuit of luxury.
+
+Yet, alas, the characters don’t get dark enough to expose the nasty underbelly
+that King’s script was clearly reaching for. The necessary depth eludes both
+pen and performance as neither writer, director nor actors are able to reach
+the story’s potential. It relies too heavily on cliches of drama: a slap here,
+a broken vase there and, of course, the Hollywood must-have, a shattered
+picture frame to signal the breaking point in a relationship.
+
+Yet the story of Mr and Mrs Blacke is an improvement over Last Call which was
+far too bland, with a story as unremarkably beige as its beautiful set and
+costumes. Mr and Mrs Blacke is commendable in its ambitions, but as yet they
+remain only ambitions.
+
+Mr and Mrs Blacke is currently playing at the Phillip Sherlock Centre for the
+Creative Arts, University of the West Indies, Mona.

--- a/source/articles/external/on-set-scoop-tallawah-goes-behind-the-scenes-at-mr-and-mrs-blacke.html.md
+++ b/source/articles/external/on-set-scoop-tallawah-goes-behind-the-scenes-at-mr-and-mrs-blacke.html.md
@@ -1,0 +1,68 @@
+---
+title: On-set scoop — Tallawah goes behind the scenes at Mr & Mrs Blacke
+date: 2012-06-17 00:00 UTC
+
+author: Tyrone Reid
+source: Tallawah
+source_url: http://www.tallawahmagazine.com/2012/06/on-set-scoop-tallawah-goes-behind.html
+---
+
+Surely there can’t be anywhere more unglamorous than this nondescript warehouse
+towards the back of the Sagicor Industrial Complex, off South Camp Road in
+Kingston. That is until you set foot inside the building on a balmy Thursday
+evening and realize that its occupants are busy making fabulous art. Welcome
+to the rehearsal and set-construction space of Eight Seven Six, the theatre
+production outfit that put on last year’s award-winning musical opus, Last Call.
+
+These days, building on the incredible momentum from last season, the company’s
+principals and technical team, are gearing up to astonish local theatergoers
+anew with Mr. & Mrs. Blacke, a dialogue-heavy marriage drama, which is a month
+away from opening at Mona’s Philip Sherlock Centre.
+
+As TALLAWAH soon discovers, putting on a show with a difference is the Eight
+Seven Six way. And, taking a page from the Broadway manual on how to succeed
+in show business, it all starts with securing a proper and dedicated working
+space that, in its own way, is conducive to the creation of theatrical magic.
+“The idea is that from the ground up, we approach putting on a show very
+differently. We try and approach it in a very professional and very
+comprehensive and First-World way,” explains the show’s writer (and male lead)
+Keiran King. “So we get a dedicated space. We recreate the theatre inside that
+space and we build everything, as I said, from the ground up.”
+
+A quick glance around the expansive room reveals aspects of the set under
+construction, as well as work tables, desks, a few chairs and props that will
+find their way into the final product come July. “We’ve been here at Sagicor
+since the middle of May and will be here until four or five days before
+opening [night]. We’ll just move everything wholesale like the week before,”
+says King. “And the idea is that the construction crew can come and see
+exactly what they need to do because everything is here to scale. Things are
+marked out on the floor. The set designers can build unimpeded by any
+distractions. So they work in the day. We come in and rehearse at night.”
+
+And rehearse they do. Just ask Keisha Patterson, the leading lady, who along
+with King makes up the cast. “These rehearsals have me on an emotional
+rollercoaster. It’s really in-depth,” she admits, curled kitten-like on a sofa.
+“This character has a lot of layers to her, and we’re into everyday rehearsals.
+So it takes a lot out of you.”
+
+But she’s not complaining. Being a natural performer from day one, Patterson is
+used to the hard work that comes with the territory. “I grew up in the theatre;
+I started as a pre-teen in theatre, so this is really my life. I’m used to
+this,” she explains, adding that her attention to detail has also come in
+handy. “I’m definitely a perfectionist. I sleep with my script. I wake up with
+it. I need to get the emotion right. It has to be true, and once that happens
+then the character is really living. And the director, Paul Issa, really gets
+in-depth, so it’s awesome.”
+
+For Issa, helming the project was simply an opportunity too good to pass up –
+especially in the wake of Last Call’s tremendous success, including an Actor
+Boy win for Best Production. “I’m very glad that they asked me to direct it.
+I was quite impressed with many aspects of Keiran’s last production, and he
+told me he’s written this play and he sent it to me and asked if I’d direct
+it, and I said yes,” explains Issa (Tartuffe).
+
+“It’s a very well-written play, I think. It’s a very unusual work,” the
+director continues. “It deals with a different kind of socio-economic bracket
+from what most Jamaican plays deal with. But I like the way it was written,
+and I like the professionalism of the crew, how they go about doing everything.
+And I am delighted to be working with such a talented cast. It’s just great."

--- a/source/articles/external/what-we-have-forceful-but-flawed-mr-and-mrs-blacke-reveals-matrimonys-dark-side.html.md
+++ b/source/articles/external/what-we-have-forceful-but-flawed-mr-and-mrs-blacke-reveals-matrimonys-dark-side.html.md
@@ -1,0 +1,55 @@
+---
+title: What we have — Forceful but flawed, Mr & Mrs Blacke reveals
+  matrimony’s dark side
+date: 2012-08-06 00:00 UTC
+
+author: Tyrone Reid
+source: Tallawah
+source_url: http://www.tallawahmagazine.com/2012/08/what-we-have-forceful-but-flawed-blacke.html
+---
+
+“There’s a storm coming,” Samantha Blacke warns her just-home-from-work
+husband Nicholas in the opening scene of Mr & Mrs Blacke, a potent but flawed
+two-hander marital drama from writer-producer Keiran King. But Samantha’s
+words are as much an admonition for her husband as they are for the audience,
+which is in for a deeply emotional trip across the unpredictable terrain of
+love and matrimony, as we eavesdrop on this young, well-to-do couple over the
+course of an evening inside the luxurious living room of their luxurious upper
+St. Andrew home.
+
+It’s a visually charming production to be sure; the set is lovely to look at
+and the overall setting is beautifully lit. But if Desperate Housewives has
+taught me anything it’s that the appearance of wholesome attractiveness is
+never to be trusted. As it happens, beneath the gorgeous façade lurks ugly
+and deep-seated emotions (rage, despair, disillusionment) that are just dying
+to come out. In other words, all is not black and white.
+
+Meticulous and mistrusting, Samantha (Patterson) is a Shakespeare-spouting
+aspiring writer with, um, issues. The hubby (King), on the other hand, is a
+successful investment banker who comes off as a burdened fellow given to
+regular bouts of cynicism. They hardly seem the perfect match. But given their
+good fortune, you can’t help but wonder what the hell are they so miserable
+about? Well, as that wise man famously said, you never know the value of what
+you’ve got till you lose it.
+
+That’s a fact the Blackes must come to terms with the hard way. What starts
+out as a quiet, relaxing evening soon deteriorates into a tempest of screaming
+and shouting and things better left unsaid. “You’re driving me crazy,” bites
+Nicholas at one point. “The feeling is mutual,” Samantha snaps back without
+missing a beat.
+
+In just a few short years, King has become known for favouring dialogue-heavy
+scripts, and Blacke is no exception with some truly witty lines and wise
+observations. But the play does sag around the middle, growing into a tedious
+longeur until the pace finally quickens and the temperature in the room takes
+a heated turn.
+
+As for the performances, King and Patterson are no great thespians, but they
+are adequately competent actors, and with Issa extending a steady hand over
+the proceedings, the turns are regularly nuanced and revealing.
+
+“Nobody wants to watch people fall out of love,” remarks one of the characters.
+And, truly, there is perhaps no line that better speaks to Mr & Mrs Blacke.
+Though a solid work with its bright moments, as a study of complicated lovers
+and trust and misunderstanding it sometimes shows its stitching and
+occasionally loses its way.

--- a/source/assets/stylesheets/components/_footer.scss
+++ b/source/assets/stylesheets/components/_footer.scss
@@ -1,6 +1,7 @@
 .footer {
   border-top: var(--border);
   font-size: var(--font-size--small);
+  margin-top: var(--spacing);
   padding-top: var(--spacing--half);
 }
 

--- a/source/assets/stylesheets/elements/_typography.scss
+++ b/source/assets/stylesheets/elements/_typography.scss
@@ -16,7 +16,6 @@ h4,
 h5,
 h6 {
   color: var(--accent-color);
-  font-family: var(--font-family);
   font-size: var(--font-size);
   line-height: var(--line-height--unleaded);
   margin: 0 0 var(--spacing--half);

--- a/source/assets/stylesheets/main.css.scss
+++ b/source/assets/stylesheets/main.css.scss
@@ -23,6 +23,7 @@
 @import "objects/stack";
 
 @import "pages/christmas";
+@import "pages/external";
 @import "pages/help";
 @import "pages/play";
 @import "pages/resume";

--- a/source/assets/stylesheets/pages/_external.scss
+++ b/source/assets/stylesheets/pages/_external.scss
@@ -1,0 +1,3 @@
+.external {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}

--- a/source/assets/stylesheets/settings/_variables.scss
+++ b/source/assets/stylesheets/settings/_variables.scss
@@ -7,7 +7,7 @@
 
   --action-color: var(--content-color);
   --action-color--hover: rgba(var(--content-color-rgb), 0.75);
-  --highlight-color: rgba(var(--content-color-rgb), 0.075);
+  --highlight-color: rgba(var(--content-color-rgb), 0.066);
   --subtle-color: rgba(var(--content-color-rgb), 0.33);
 
   // Typography

--- a/source/layouts/external.erb
+++ b/source/layouts/external.erb
@@ -1,0 +1,24 @@
+<% wrap_layout :layout do %>
+  <section class="section section--padded">
+    <aside class="section__content section__content--slim fine-print external-content__disclaimer">
+      The content on this page is by a third party and reproduced from
+      its original source.
+    </aside>
+
+    <article class="section__content section__content--slim external-content">
+      <header>
+        <h1>
+          <%= current_article.data.title %>
+        </h1>
+
+        <p>
+          <%= current_article.data.author %><br />
+          <%= link_to current_article.data.source, current_article.data.source_url %><br />
+          <%= current_article.date %>
+        </p>
+      </header>
+
+      <%= yield %>
+    </article>
+  </section>
+<% end %>

--- a/source/layouts/external.erb
+++ b/source/layouts/external.erb
@@ -1,24 +1,68 @@
-<% wrap_layout :layout do %>
-  <section class="section section--padded">
-    <aside class="section__content section__content--slim fine-print external-content__disclaimer">
-      The content on this page is by a third party and reproduced from
-      its original source.
-    </aside>
+<!DOCTYPE html>
+<html
+  lang="<%= I18n.locale %>"
+  class="
+    <% if current_article %>
+      <% if current_article.data.theme %>
+        <%= "themes--#{current_article.data.theme}" %>
+      <% else %>
+        <%= "themes--#{current_article.data.category}" %>
+      <% end %>
+    <% elsif current_page.data.theme %>
+      <%= "themes--#{current_page.data.theme}" %>
+    <% end %>
+    "
+>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title><%= data.site.title %></title>
+    <%= stylesheet_link_tag "main" %>
+  </head>
 
-    <article class="section__content section__content--slim external-content">
-      <header>
-        <h1>
-          <%= current_article.data.title %>
-        </h1>
+  <body class="site">
+    <main
+      class="
+        <%= current_resource.options[:layout] if current_resource.options[:layout].present? %>
+        "
+      role="main"
+    >
+      <section class="section section--padded">
+        <article class="section__content section__content--slim">
+          <aside class="fine-print">
+            This content is cached from another site.
+            <% if current_article.data.source_url %>
+              <br />
+              <%= link_to "View original source", current_article.data.source_url %>
+            <% end %>
+          </aside>
 
-        <p>
-          <%= current_article.data.author %><br />
-          <%= link_to current_article.data.source, current_article.data.source_url %><br />
-          <%= current_article.date %>
-        </p>
-      </header>
+          <hr />
 
-      <%= yield %>
-    </article>
-  </section>
-<% end %>
+          <header>
+            <h1 class="u-margin-top">
+              <% if current_article.data.source_url %>
+                <%= link_to current_article.data.title, current_article.data.source_url %>
+              <% else %>
+                <%= current_article.data.title %>
+              <% end %>
+            </h1>
+
+            <p>
+              by <%= current_article.data.author %>
+              <br />
+              from <%= current_article.data.source %>
+              <br />
+              <%= date_to_s current_article.data.date %>
+            </p>
+          </header>
+
+          <%= yield %>
+        </article>
+      </section>
+    </main>
+
+    <%= partial "partials/analytics" %>
+  </body>
+</html>


### PR DESCRIPTION
## Problem
Some of the content on the site links to Jamaican websites, which do not always migrate older content at stable URLs. Archiving a copy of the relevant external content allows the site to maintain the reliability of linking to primary sources, even if those sources no longer exist.

## Solution
This commit adds the ability to view content archived from external sources.

## After
<img width="375" alt="Screen Shot 2020-09-13 at 17 26 35" src="https://user-images.githubusercontent.com/28635708/93029041-596fbe00-f5e6-11ea-9451-48f66509e6f2.png">
